### PR TITLE
Removed push workflow trigger

### DIFF
--- a/.github/workflows/check-data-and-links.yml
+++ b/.github/workflows/check-data-and-links.yml
@@ -10,17 +10,6 @@ on:
       - "README.md"
       - "CONTRIBUTING.md"
       - "package.json"
-  push:
-    branches:
-      - main
-    paths:
-      - "data/**"
-      - "countries/**"
-      - "scripts/**"
-      - ".github/workflows/**"
-      - "README.md"
-      - "CONTRIBUTING.md"
-      - "package.json"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- Removed push workflow trigger as it isn't necessary for Check Data And Links if the workflow already runs on pull requests.

